### PR TITLE
Fix potential regex DDOS

### DIFF
--- a/src/languageDetector.js
+++ b/src/languageDetector.js
@@ -90,7 +90,7 @@ function enableTextCleanup(bool) {
  */
 function getCleanTxt(str) {
     // Remove URLS
-    str = str.replace(/[hw]((ttps?:\/\/(www\.)?)|ww\.)([^\s/?.#-]+\.?)+(\/\S*)?/gi, ' ')
+    str = str.replace(/[hw](?:(?:ttps?:\/\/(?:www\.)?)|ww\.)[^\s]+/gi, ' ')
     // Remove emails
     str = str.replace(/[a-zA-Z0-9.!$%&’+_`-]+@[A-Za-z0-9.-]+\.[A-Za-z0-9-]{2,64}/g, ' ')
     // Remove .com domains


### PR DESCRIPTION
- The original regex had ([^\s/?.#-]+\.?)+ — a nested quantifier with an optional element that causes exponential backtracking on text containing dots and non-URL characters (common in Spanish, French, etc.). 
- The simplified regex matches the same URL patterns (starts with http://, https://, htt://, www., ww., then everything until whitespace) without backtracking risk.